### PR TITLE
Optimize performance when dropper has invalid recipes inside

### DIFF
--- a/src/main/java/re/domi/easyautocrafting/CraftingDropper.java
+++ b/src/main/java/re/domi/easyautocrafting/CraftingDropper.java
@@ -59,10 +59,11 @@ public class CraftingDropper
 	    DropperItemsCache itemsCache = (DropperItemsCache) dropper;
         CraftingRecipe recipe = cache.get();
 
-        if (!InventoryUtil.compareList(itemsCache.getCachedList(), listForCompare) || itemsCache.getCachedList().isEmpty() && (recipe == null || !recipe.matches(craftingInventory, world) )) //check if inventory has changed
+        if (!InventoryUtil.compareList(itemsCache.getCachedList(), listForCompare) || (itemsCache.getCachedList().isEmpty() && (recipe == null || !recipe.matches(craftingInventory, world)) )) //check if inventory has changed
         {
 	        recipe = world.getRecipeManager().getFirstMatch(RecipeType.CRAFTING, craftingInventory, world).orElse(null);
 	        itemsCache.setCachedList(InventoryUtil.deepCopy(listForCompare));
+		cache.set(recipe);
         }
 
         if (recipe != null)

--- a/src/main/java/re/domi/easyautocrafting/CraftingDropper.java
+++ b/src/main/java/re/domi/easyautocrafting/CraftingDropper.java
@@ -59,7 +59,11 @@ public class CraftingDropper
 
         if (recipe == null || !recipe.matches(craftingInventory, world))
         {
-            recipe = world.getRecipeManager().getFirstMatch(RecipeType.CRAFTING, craftingInventory, world).orElse(null);
+			DropperItemsCache itemsCache = (DropperItemsCache) dropper;
+			if(!InventoryUtil.compareList(itemsCache.getCachedList(), ingredients)){
+				recipe = world.getRecipeManager().getFirstMatch(RecipeType.CRAFTING, craftingInventory, world).orElse(null);
+				itemsCache.setCachedList(List.copyOf(ingredients));
+			}
         }
 
         if (recipe != null)

--- a/src/main/java/re/domi/easyautocrafting/DropperItemsCache.java
+++ b/src/main/java/re/domi/easyautocrafting/DropperItemsCache.java
@@ -1,0 +1,12 @@
+package re.domi.easyautocrafting;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.CraftingRecipe;
+
+import java.util.List;
+
+public interface DropperItemsCache
+{
+	List<ItemStack> getCachedList();
+    void setCachedList(List<ItemStack> r);
+}

--- a/src/main/java/re/domi/easyautocrafting/EasyAutoCrafting.java
+++ b/src/main/java/re/domi/easyautocrafting/EasyAutoCrafting.java
@@ -4,6 +4,8 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.impl.event.lifecycle.LoadedChunksCache;
 
+import java.util.ArrayList;
+
 public class EasyAutoCrafting implements ModInitializer
 {
     @Override
@@ -16,7 +18,11 @@ public class EasyAutoCrafting implements ModInitializer
                 server.getWorlds().forEach(
                     w -> ((LoadedChunksCache)w).fabric_getLoadedChunks().forEach(
                         c -> c.getBlockEntities().values().stream().filter(DropperRecipeCache.class::isInstance).forEach(
-                            d -> ((DropperRecipeCache)d).set(null))));
+                            d -> {
+	                            ((DropperRecipeCache) d).set(null);
+	                            ((DropperItemsCache) d).setCachedList(new ArrayList<>(9));
+                            }
+                        )));
             }
         });
     }

--- a/src/main/java/re/domi/easyautocrafting/EasyAutoCrafting.java
+++ b/src/main/java/re/domi/easyautocrafting/EasyAutoCrafting.java
@@ -17,12 +17,19 @@ public class EasyAutoCrafting implements ModInitializer
             {
                 server.getWorlds().forEach(
                     w -> ((LoadedChunksCache)w).fabric_getLoadedChunks().forEach(
-                        c -> c.getBlockEntities().values().stream().filter(DropperRecipeCache.class::isInstance).forEach(
-                            d -> {
-	                            ((DropperRecipeCache) d).set(null);
-	                            ((DropperItemsCache) d).setCachedList(new ArrayList<>(9));
-                            }
-                        )));
+                        c -> {
+	                        c.getBlockEntities().values().stream().filter(DropperRecipeCache.class::isInstance).forEach(
+		                        d -> {
+			                        ((DropperRecipeCache) d).set(null);
+		                        }
+	                        );
+	                        c.getBlockEntities().values().stream().filter(DropperItemsCache.class::isInstance).forEach(
+		                        d -> {
+			                        ((DropperItemsCache) d).setCachedList(new ArrayList<>(9));
+		                        }
+	                        );
+                        }
+						));
             }
         });
     }

--- a/src/main/java/re/domi/easyautocrafting/InventoryUtil.java
+++ b/src/main/java/re/domi/easyautocrafting/InventoryUtil.java
@@ -211,4 +211,15 @@ public class InventoryUtil
 
         return copy;
     }
+	public static boolean compareList(List<ItemStack> preList, List<ItemStack> afterList)
+	{
+		if(preList == null || preList.size() != afterList.size()){
+			return false;
+		}
+		for (int i =0; i<preList.size(); i++){
+			if(!preList.get(i).isItemEqual(afterList.get(i)))
+				return false;
+		}
+		return true;
+	}
 }

--- a/src/main/java/re/domi/easyautocrafting/InventoryUtil.java
+++ b/src/main/java/re/domi/easyautocrafting/InventoryUtil.java
@@ -200,7 +200,7 @@ public class InventoryUtil
         return stacks.isEmpty();
     }
 
-    private static List<ItemStack> deepCopy(List<ItemStack> list)
+    public static List<ItemStack> deepCopy(List<ItemStack> list)
     {
         List<ItemStack> copy = new ArrayList<>(list.size());
 
@@ -216,8 +216,8 @@ public class InventoryUtil
 		if(preList == null || preList.size() != afterList.size()){
 			return false;
 		}
-		for (int i =0; i<preList.size(); i++){
-			if(!preList.get(i).isItemEqual(afterList.get(i)))
+		for (int i =0; i < preList.size(); i++){
+			if(!preList.get(i).isOf(afterList.get(i).getItem()))
 				return false;
 		}
 		return true;

--- a/src/main/java/re/domi/easyautocrafting/mixin/DropperBlockEntityMixin.java
+++ b/src/main/java/re/domi/easyautocrafting/mixin/DropperBlockEntityMixin.java
@@ -9,12 +9,16 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import org.spongepowered.asm.mixin.Mixin;
 import re.domi.easyautocrafting.CraftingDropper;
+import re.domi.easyautocrafting.DropperItemsCache;
 import re.domi.easyautocrafting.DropperRecipeCache;
 
+import java.util.List;
+
 @Mixin(DropperBlockEntity.class)
-public class DropperBlockEntityMixin extends DispenserBlockEntity implements DropperRecipeCache
+public class DropperBlockEntityMixin extends DispenserBlockEntity implements DropperRecipeCache, DropperItemsCache
 {
     private CraftingRecipe cachedRecipe;
+	private List<ItemStack> cachedList;
 
     public DropperBlockEntityMixin(BlockPos pos, BlockState state)
     {
@@ -38,9 +42,21 @@ public class DropperBlockEntityMixin extends DispenserBlockEntity implements Dro
         return this.cachedRecipe;
     }
 
+	@Override
+	public void set(CraftingRecipe r)
+	{
+		this.cachedRecipe = r;
+	}
+
+	@Override
+	public List<ItemStack> getCachedList()
+	{
+		return this.cachedList;
+	}
+
     @Override
-    public void set(CraftingRecipe r)
+    public void setCachedList(List<ItemStack> r)
     {
-        this.cachedRecipe = r;
+        this.cachedList = r;
     }
 }


### PR DESCRIPTION
Context : see https://spark.lucko.me/CTg7XIweRT

its with 16 droppers, 6gt observer clocks.

If we have empty droppers ticking (with crafting table) pointing nowhere, it will still cause lag from searching recipe continuously.
This patch solves it by caching inventory contents(Lists of itemstacks) and compare if its changed.

After patch : https://spark.lucko.me/bNVnMlWU9b (its not even in list)

It also solves bug that you can multiply consume rates to get less return : because it didn't use recipe itself, it used inventory!
